### PR TITLE
Includes have "extensions" not "extension"

### DIFF
--- a/src/Helmich/TypoScriptParser/Tokenizer/Tokenizer.php
+++ b/src/Helmich/TypoScriptParser/Tokenizer/Tokenizer.php
@@ -40,7 +40,7 @@ class Tokenizer implements TokenizerInterface
     const TOKEN_INCLUDE_STATEMENT = ',^
         <INCLUDE_TYPOSCRIPT:\s+
         source="(?<type>FILE|DIR):(?<filename>[^"]+)"
-        (?:\s+extension="(?<extension>[^"]+)")?
+        (?:\s+extensions="(?<extensions>[^"]+)")?
         \s*>
     $,x';
 


### PR DESCRIPTION
* As documented at
  https://docs.typo3.org/typo3cms/TyposcriptSyntaxReference/Syntax/Includes/Index.html