### PR TITLE
Object identifiers may contain `:` characters

### DIFF
--- a/src/Helmich/TypoScriptParser/Tokenizer/Tokenizer.php
+++ b/src/Helmich/TypoScriptParser/Tokenizer/Tokenizer.php
@@ -12,8 +12,8 @@ class Tokenizer implements TokenizerInterface
     const TOKEN_CONDITION_END = ',^\[(global|end)\],i';
 
     const TOKEN_OBJECT_NAME = ',^(CASE|CLEARGIF|COA(?:_INT)?|COBJ_ARRAY|COLUMNS|CTABLE|EDITPANEL|FILES?|FLUIDTEMPLATE|FORM|HMENU|HRULER|TEXT|IMAGE|IMG_RESOURCE|IMGTEXT|LOAD_REGISTER|MEDIA|MULTIMEDIA|OTABLE|QTOBJECT|RECORDS|RESTORE_REGISTER|SEARCHRESULT|SVG|SWFOBJECT|TEMPLATE|USER(?:_INT)?|GIFBUILDER|[GT]MENU(?:_LAYERS)?|(?:G|T|JS|IMG)MENUITEM)$,';
-    const TOKEN_OBJECT_ACCESSOR = ',^([a-zA-Z0-9_\-\\\\]+(?:\.[a-zA-Z0-9_\-\\\\]+)*)$,';
-    const TOKEN_OBJECT_REFERENCE = ',^\.?([a-zA-Z0-9_\-\\\\]+(?:\.[a-zA-Z0-9_\-\\\\]+)*)$,';
+    const TOKEN_OBJECT_ACCESSOR = ',^([a-zA-Z0-9_\-\\\\:]+(?:\.[a-zA-Z0-9_\-\\\\:]+)*)$,';
+    const TOKEN_OBJECT_REFERENCE = ',^\.?([a-zA-Z0-9_\-\\\\:]+(?:\.[a-zA-Z0-9_\-\\\\:]+)*)$,';
 
     const TOKEN_NESTING_START = ',^\{$,';
     const TOKEN_NESTING_END = ',^\}$,';
@@ -26,11 +26,11 @@ class Tokenizer implements TokenizerInterface
         \)
     $,x';
     const TOKEN_OPERATOR_LINE = ',^
-        ([a-zA-Z0-9_\-\\\\]+(?:\.[a-zA-Z0-9_\-\\\\]+)*)  # Left value (object accessor)
-        (\s*)                                            # Whitespace
-        (=|:=|<=|<|>|\{|\()                              # Operator
-        (\s*)                                            # More whitespace
-        (.*?)                                            # Right value
+        ([a-zA-Z0-9_\-\\\\:]+(?:\.[a-zA-Z0-9_\-\\\\:]+)*)  # Left value (object accessor)
+        (\s*)                                              # Whitespace
+        (=|:=|<=|<|>|\{|\()                                # Operator
+        (\s*)                                              # More whitespace
+        (.*?)                                              # Right value
     $,x';
     const TOKEN_INCLUDE_STATEMENT = ',^
         <INCLUDE_TYPOSCRIPT:\s+

--- a/tests/functional/Parser/Fixtures/Assignments/issue_14.php
+++ b/tests/functional/Parser/Fixtures/Assignments/issue_14.php
@@ -1,0 +1,19 @@
+<?php
+use Helmich\TypoScriptParser\Parser\AST\NestedAssignment;
+use Helmich\TypoScriptParser\Parser\AST\ObjectPath;
+use Helmich\TypoScriptParser\Parser\AST\Operator\Assignment;
+use Helmich\TypoScriptParser\Parser\AST\Operator\ObjectCreation;
+use Helmich\TypoScriptParser\Parser\AST\Scalar;
+
+return [
+    new NestedAssignment(
+        new ObjectPath('page', 'page'), [
+            new NestedAssignment(
+                new ObjectPath('page.meta', 'meta'), [
+                    new ObjectCreation(new ObjectPath('page.meta.foo:bar.cObject', 'foo:bar.cObject'), new Scalar("TEXT"), 3),
+                    new Assignment(new ObjectPath('page.meta.foo:bar.cObject.value', 'foo:bar.cObject.value'), new Scalar("qux"), 4)
+                ], 2
+            )
+        ], 1
+    )
+];

--- a/tests/functional/Parser/Fixtures/Assignments/issue_14.typoscript
+++ b/tests/functional/Parser/Fixtures/Assignments/issue_14.typoscript
@@ -1,0 +1,6 @@
+page {
+    meta {
+        foo:bar.cObject = TEXT
+        foo:bar.cObject.value = qux
+    }
+}

--- a/tests/functional/Parser/ParserTest.php
+++ b/tests/functional/Parser/ParserTest.php
@@ -17,7 +17,6 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     public function dataForParserTest()
     {
         $files = glob(__DIR__ . '/Fixtures/*/*.typoscript');
-        //$files = glob(__DIR__ . '/Fixtures/*/relative_copy.typoscript');
         foreach ($files as $file) {
             $outputFile = str_replace('.typoscript', '.php', $file);
             $output     = include $outputFile;

--- a/tests/unit/Tokenizer/TokenizerTest.php
+++ b/tests/unit/Tokenizer/TokenizerTest.php
@@ -35,6 +35,22 @@ class TokenizerTest extends \PHPUnit_Framework_TestCase
             new Token(Token::TYPE_WHITESPACE, " ", 1),
             new Token(Token::TYPE_RIGHTVALUE, "bar", 1)
         ]];
+
+        yield ["foo.bar = baz", [
+            new Token(Token::TYPE_OBJECT_IDENTIFIER, "foo.bar", 1),
+            new Token(Token::TYPE_WHITESPACE, " ", 1),
+            new Token(Token::TYPE_OPERATOR_ASSIGNMENT, "=", 1),
+            new Token(Token::TYPE_WHITESPACE, " ", 1),
+            new Token(Token::TYPE_RIGHTVALUE, "baz", 1)
+        ]];
+
+        yield ["foo.bar.baz = baz", [
+            new Token(Token::TYPE_OBJECT_IDENTIFIER, "foo.bar.baz", 1),
+            new Token(Token::TYPE_WHITESPACE, " ", 1),
+            new Token(Token::TYPE_OPERATOR_ASSIGNMENT, "=", 1),
+            new Token(Token::TYPE_WHITESPACE, " ", 1),
+            new Token(Token::TYPE_RIGHTVALUE, "baz", 1)
+        ]];
     }
 
     public function dataInvalidForTokenizer()


### PR DESCRIPTION
Fixes #14.

Credits to @mbrodala for reporting