### PR TITLE
Additional cleanup for #18

### DIFF
--- a/src/Helmich/TypoScriptParser/Parser/Printer/PrettyPrinter.php
+++ b/src/Helmich/TypoScriptParser/Parser/Printer/PrettyPrinter.php
@@ -81,7 +81,7 @@ class PrettyPrinter implements ASTPrinterInterface
         if ($operator instanceof Copy) {
             $output->writeln($this->getIndent($nesting) . $operator->object->relativeName . ' < ' . $targetObjectPath);
         } elseif ($operator instanceof Reference) {
-            $output->writeln($this->getIndent($nesting) . $operator->object->relativeName . ' <= ' . $targetObjectPath);
+            $output->writeln($this->getIndent($nesting) . $operator->object->relativeName . ' =< ' . $targetObjectPath);
         }
     }
 

--- a/src/Helmich/TypoScriptParser/Tokenizer/Tokenizer.php
+++ b/src/Helmich/TypoScriptParser/Tokenizer/Tokenizer.php
@@ -28,7 +28,7 @@ class Tokenizer implements TokenizerInterface
     const TOKEN_OPERATOR_LINE = ',^
         ([a-zA-Z0-9_\-\\\\:\$\{\}]+(?:\.[a-zA-Z0-9_\-\\\\:\$\{\}]+)*)  # Left value (object accessor)
         (\s*)                                                          # Whitespace
-        (=<|=|:=|<=|<|>|\{|\()                                            # Operator
+        (=<|=|:=|<|>|\{|\()                                            # Operator
         (\s*)                                                          # More whitespace
         (.*?)                                                          # Right value
     $,x';
@@ -122,7 +122,6 @@ class Tokenizer implements TokenizerInterface
                 return TokenInterface::TYPE_OPERATOR_ASSIGNMENT;
             case '<':
                 return TokenInterface::TYPE_OPERATOR_COPY;
-            case '<=':
             case '=<':
                 return TokenInterface::TYPE_OPERATOR_REFERENCE;
             case ':=':
@@ -167,7 +166,7 @@ class Tokenizer implements TokenizerInterface
             $tokens->append(TokenInterface::TYPE_WHITESPACE, $matches[4], $currentLine);
         }
 
-        if (($matches[3] === '<' || $matches[3] === '<='  || $matches[3] === '=<') && preg_match(self::TOKEN_OBJECT_REFERENCE, $matches[5])) {
+        if (($matches[3] === '<' || $matches[3] === '=<') && preg_match(self::TOKEN_OBJECT_REFERENCE, $matches[5])) {
             $tokens->append(
                 TokenInterface::TYPE_OBJECT_IDENTIFIER,
                 $matches[5],

--- a/tests/functional/Parser/Fixtures/Assignments/relative_reference.typoscript
+++ b/tests/functional/Parser/Fixtures/Assignments/relative_reference.typoscript
@@ -1,2 +1,2 @@
 bar = baz
-baz <= .bar
+baz =< .bar

--- a/tests/functional/Parser/Fixtures/Assignments/relative_reference_nested.typoscript
+++ b/tests/functional/Parser/Fixtures/Assignments/relative_reference_nested.typoscript
@@ -1,4 +1,4 @@
 foo {
     bar = baz
-    baz <= .bar
+    baz =< .bar
 }

--- a/tests/functional/Parser/Fixtures/Assignments/simple_reference.typoscript
+++ b/tests/functional/Parser/Fixtures/Assignments/simple_reference.typoscript
@@ -1,2 +1,2 @@
 foo = bar
-bar <= foo
+bar =< foo

--- a/tests/unit/Tokenizer/TokenizerTest.php
+++ b/tests/unit/Tokenizer/TokenizerTest.php
@@ -51,6 +51,14 @@ class TokenizerTest extends \PHPUnit_Framework_TestCase
             new Token(Token::TYPE_WHITESPACE, " ", 1),
             new Token(Token::TYPE_RIGHTVALUE, "baz", 1)
         ]];
+
+        yield ["foo =< bar", [
+            new Token(Token::TYPE_OBJECT_IDENTIFIER, "foo", 1),
+            new Token(Token::TYPE_WHITESPACE, " ", 1),
+            new Token(Token::TYPE_OPERATOR_REFERENCE, "=<", 1),
+            new Token(Token::TYPE_WHITESPACE, " ", 1),
+            new Token(Token::TYPE_RIGHTVALUE, "bar", 1)
+        ]];
     }
 
     public function dataInvalidForTokenizer()

--- a/tests/unit/Tokenizer/TokenizerTest.php
+++ b/tests/unit/Tokenizer/TokenizerTest.php
@@ -57,7 +57,7 @@ class TokenizerTest extends \PHPUnit_Framework_TestCase
             new Token(Token::TYPE_WHITESPACE, " ", 1),
             new Token(Token::TYPE_OPERATOR_REFERENCE, "=<", 1),
             new Token(Token::TYPE_WHITESPACE, " ", 1),
-            new Token(Token::TYPE_RIGHTVALUE, "bar", 1)
+            new Token(Token::TYPE_OBJECT_IDENTIFIER, "bar", 1)
         ]];
     }
 


### PR DESCRIPTION
- Add test cases
- Adjust code printer
- Do not parse `<=` as reference, anymore