### PR TITLE
Fix evaluation of custom conditions, attempt 2

### DIFF
--- a/src/Helmich/TypoScriptParser/Tokenizer/Tokenizer.php
+++ b/src/Helmich/TypoScriptParser/Tokenizer/Tokenizer.php
@@ -278,9 +278,9 @@ class Tokenizer implements TokenizerInterface
         $simpleTokens = [
             self::TOKEN_COMMENT_ONELINE   => TokenInterface::TYPE_COMMENT_ONELINE,
             self::TOKEN_NESTING_END       => TokenInterface::TYPE_BRACE_CLOSE,
-            self::TOKEN_CONDITION         => TokenInterface::TYPE_CONDITION,
             self::TOKEN_CONDITION_ELSE    => TokenInterface::TYPE_CONDITION_ELSE,
             self::TOKEN_CONDITION_END     => TokenInterface::TYPE_CONDITION_END,
+            self::TOKEN_CONDITION         => TokenInterface::TYPE_CONDITION,
             self::TOKEN_INCLUDE_STATEMENT => TokenInterface::TYPE_INCLUDE,
         ];
 

--- a/tests/functional/Parser/Fixtures/Assignments/condition_custom.php
+++ b/tests/functional/Parser/Fixtures/Assignments/condition_custom.php
@@ -1,0 +1,12 @@
+<?php
+
+use Helmich\TypoScriptParser\Parser\AST\ConditionalStatement;
+use Helmich\TypoScriptParser\Parser\AST\ObjectPath;
+use Helmich\TypoScriptParser\Parser\AST\Operator\Assignment;
+use Helmich\TypoScriptParser\Parser\AST\Scalar;
+
+return [
+    new ConditionalStatement('Foo\Bar\Custom = 42', [
+        new Assignment(new ObjectPath('foo', 'foo'), new Scalar('bar'), 2)
+    ], [], 1)
+];

--- a/tests/functional/Parser/Fixtures/Assignments/condition_custom.php
+++ b/tests/functional/Parser/Fixtures/Assignments/condition_custom.php
@@ -6,7 +6,7 @@ use Helmich\TypoScriptParser\Parser\AST\Operator\Assignment;
 use Helmich\TypoScriptParser\Parser\AST\Scalar;
 
 return [
-    new ConditionalStatement('Foo\Bar\Custom = 42', [
+    new ConditionalStatement('[Foo\Bar\Custom = 42]', [
         new Assignment(new ObjectPath('foo', 'foo'), new Scalar('bar'), 2)
     ], [], 1)
 ];

--- a/tests/functional/Parser/Fixtures/Assignments/condition_custom.typoscript
+++ b/tests/functional/Parser/Fixtures/Assignments/condition_custom.typoscript
@@ -1,0 +1,3 @@
+[Foo\Bar\Custom = 42]
+foo = bar
+[global]


### PR DESCRIPTION
Building on #19, adding:

- new unit tests for the added behaviour
- raised precedence for `[else]`/`[end]` tokens (otherwise, those will be parsed as custom conditions)