### PR TITLE
FEATURE: Allow to not modify lineendings

### DIFF
--- a/src/Helmich/TypoScriptParser/Tokenizer/Tokenizer.php
+++ b/src/Helmich/TypoScriptParser/Tokenizer/Tokenizer.php
@@ -40,10 +40,25 @@ class Tokenizer implements TokenizerInterface
     $,x';
 
     /**
-     * Tokenizer constructor.
+     * @var string
      */
-    public function __construct()
+    protected $eolChar;
+
+    /**
+     * @var bool
+     */
+    protected $convertLineendings;
+
+    /**
+     * Tokenizer constructor.
+     *
+     * @param string $eolChar Line ending to use for tokenizing.
+     * @param bool $convertLineendings Whether to convert lineendings to unix one or not.
+     */
+    public function __construct($eolChar = '\n', $convertLineendings = true)
     {
+        $this->eolChar = $eolChar;
+        $this->convertLineendings = $convertLineendings;
     }
 
     /**
@@ -53,12 +68,14 @@ class Tokenizer implements TokenizerInterface
      */
     public function tokenizeString($inputString)
     {
-        $inputString = $this->preprocessContent($inputString);
+        if ($this->convertLineendings) {
+            $inputString = $this->preprocessContent($inputString);
+        }
 
         $tokens = new TokenStreamBuilder();
         $state  = new MultilineTokenBuilder();
 
-        $lines   = explode("\n", $inputString);
+        $lines   = explode($this->eolChar, $inputString);
         $scanner = new Scanner($lines);
 
         foreach ($scanner as $line) {
@@ -67,7 +84,7 @@ class Tokenizer implements TokenizerInterface
             }
 
             if ($tokens->count() !== 0) {
-                $tokens->append(TokenInterface::TYPE_WHITESPACE, "\n", $line->index() - 1);
+                $tokens->append(TokenInterface::TYPE_WHITESPACE, $this->eolChar, $line->index() - 1);
             }
 
             if ($matches = $line->scan(self::TOKEN_WHITESPACE)) {

--- a/src/Helmich/TypoScriptParser/Tokenizer/Tokenizer.php
+++ b/src/Helmich/TypoScriptParser/Tokenizer/Tokenizer.php
@@ -68,9 +68,7 @@ class Tokenizer implements TokenizerInterface
      */
     public function tokenizeString($inputString)
     {
-        if ($this->convertLineendings) {
-            $inputString = $this->preprocessContent($inputString);
-        }
+        $inputString = $this->preprocessContent($inputString);
 
         $tokens = new TokenStreamBuilder();
         $state  = new MultilineTokenBuilder();
@@ -154,6 +152,9 @@ class Tokenizer implements TokenizerInterface
 
     private function preprocessContent($content)
     {
+        if (!$this->convertLineendings) {
+            return $content;
+        }
         // Replace CRLF with LF.
         $content = str_replace("\r\n", "\n", $content);
 

--- a/src/Helmich/TypoScriptParser/Tokenizer/Tokenizer.php
+++ b/src/Helmich/TypoScriptParser/Tokenizer/Tokenizer.php
@@ -55,7 +55,7 @@ class Tokenizer implements TokenizerInterface
      * @param string $eolChar Line ending to use for tokenizing.
      * @param bool $convertLineendings Whether to convert lineendings to unix one or not.
      */
-    public function __construct($eolChar = '\n', $convertLineendings = true)
+    public function __construct($eolChar = "\n", $convertLineendings = true)
     {
         $this->eolChar = $eolChar;
         $this->convertLineendings = $convertLineendings;


### PR DESCRIPTION
* To allow integration as tokenizer into PHP_CodeSniffer.
* PHP_CodeSniffer detects the line ending and calculates column and line
  using the lineending.
* Adjusting line ending will break this process.
* Provide a way to keep old behaviour in a default way, but also to not
  break PHP_CodeSniffer.