### PR TITLE
[BUGFIX] Handle new conditions as end of previous condition

### DIFF
--- a/src/Helmich/TypoScriptParser/Parser/Parser.php
+++ b/src/Helmich/TypoScriptParser/Parser/Parser.php
@@ -227,6 +227,17 @@ class Parser implements ParserInterface
                 $inElseBranch = true;
                 $subContext   = $subContext->withStatements($elseStatements);
                 $state->next();
+            } elseif ($state->token()->getType() === TokenInterface::TYPE_CONDITION) {
+                $state->statements()->append(
+                    $this->builder->condition(
+                        $condition,
+                        $ifStatements->getArrayCopy(),
+                        $elseStatements->getArrayCopy(),
+                        $conditionLine
+                    )
+                );
+                $this->parseCondition($state);
+                break;
             }
 
             if ($state->token()->getType() === TokenInterface::TYPE_OBJECT_IDENTIFIER) {


### PR DESCRIPTION
The TYPO3 core parser interprets the start of a new condition as the end of the previous one (even if no end tag is given).