### PR TITLE
[Dep] Add PHP 8.1 support

### DIFF
--- a/.github/workflows/php-downstream.yml
+++ b/.github/workflows/php-downstream.yml
@@ -5,9 +5,9 @@ on:
 
 jobs:
   build:
-    strategy:      
+    strategy:
       matrix:
-        php-versions: ["7.2", "7.3", "7.4", "8.0"]
+        php-versions: ["7.2", "7.3", "7.4", "8.0", "8.1"]
         symfony-versions: ["~3.0", "~4.0", "~5.0"]
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -17,12 +17,12 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: martin-helmich/typo3-typoscript-lint
-    
+
     - name: Checkout PR
       uses: actions/checkout@v2
       with:
         path: .dev/typo3-typoscript-parser
-    
+
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
@@ -31,7 +31,7 @@ jobs:
         coverage: pcov
       env:
         COMPOSER_TOKEN: ${{ github.token }}
-    
+
     - name: Validate composer.json and composer.lock
       run: composer validate
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,22 +10,22 @@ on:
 
 jobs:
   build:
-    strategy:      
+    strategy:
       matrix:
-        php-versions: ["7.2", "7.3", "7.4", "8.0"]
+        php-versions: ["7.2", "7.3", "7.4", "8.0", "8.1"]
         symfony-versions: ["~3.0", "~4.0", "~5.0"]
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v1
-      
+
     - name: Setup PHP
       uses: shivammathur/setup-php@v1
       with:
         php-version: ${{ matrix.php-versions }}
         extensions: mbstring, intl, json
         coverage: pcov
-    
+
     - name: Validate composer.json and composer.lock
       run: composer validate
 
@@ -40,6 +40,6 @@ jobs:
 
     - name: Run type checker
       run: ./vendor/bin/psalm
-      
+
     - name: Run unit tests
       run: ./vendor/bin/phpunit --testdox

--- a/src/Parser/TokenStream.php
+++ b/src/Parser/TokenStream.php
@@ -93,6 +93,7 @@ class TokenStream implements Iterator, \ArrayAccess
      * @param TokenInterface $value
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         throw new BadMethodCallException('changing a token stream is not permitted');
@@ -102,6 +103,7 @@ class TokenStream implements Iterator, \ArrayAccess
      * @param int $offset
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         throw new BadMethodCallException('changing a token stream is not permitted');

--- a/tests/unit/Parser/AST/StatementTest.php
+++ b/tests/unit/Parser/AST/StatementTest.php
@@ -9,8 +9,6 @@ class StatementTest extends TestCase
     public function dataForInvalidSourceLines()
     {
         yield [0];
-        yield [0.1];
-        yield [-0.1];
         yield [-1];
         yield [-PHP_INT_MAX];
     }


### PR DESCRIPTION
Handle deprecation notice in php 8.1:

```bash
Remaining self deprecation notices (4)

  1x: Implicit conversion from float 0.1 to int loses precision
    1x in StatementTest::testInvalidSourceLineThrowsException from Helmich\TypoScriptParser\Tests\Unit\Parser\AST

  1x: Implicit conversion from float -0.1 to int loses precision
    1x in StatementTest::testInvalidSourceLineThrowsException from Helmich\TypoScriptParser\Tests\Unit\Parser\AST

  1x: Return type of Helmich\TypoScriptParser\Parser\TokenStream::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
    1x in TokenStreamTest::setUp from Helmich\TypoScriptParser\Tests\Unit\Parser

  1x: Return type of Helmich\TypoScriptParser\Parser\TokenStream::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
    1x in TokenStreamTest::setUp from Helmich\TypoScriptParser\Tests\Unit\Parser
```