### PR TITLE
Raise required PHP version to >=8.1

### DIFF
--- a/.github/workflows/php-coverage.yml
+++ b/.github/workflows/php-coverage.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "7.4"
+          php-version: "8.2"
           extensions: mbstring, intl, json
           coverage: pcov
 

--- a/.github/workflows/php-downstream.yml
+++ b/.github/workflows/php-downstream.yml
@@ -7,13 +7,8 @@ jobs:
   build:
     strategy:
       matrix:
-        php-versions: ["7.4", "8.0", "8.1", "8.2", "8.3"]
+        php-versions: ["8.1", "8.2", "8.3"]
         symfony-versions: ["^5.4", "^6.4"]
-        exclude:
-          - php-versions: "7.4"
-            symfony-versions: "^6.4"
-          - php-versions: "8.0"
-            symfony-versions: "^6.4"
     runs-on: ubuntu-latest
     continue-on-error: true
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,13 +12,8 @@ jobs:
   build:
     strategy:
       matrix:
-        php-versions: ["7.4", "8.0", "8.1", "8.2", "8.3"]
+        php-versions: ["8.1", "8.2", "8.3"]
         symfony-versions: [ "^5.4", "^6.4" ]
-        exclude:
-          - php-versions: "7.4"
-            symfony-versions: "^6.4"
-          - php-versions: "8.0"
-            symfony-versions: "^6.4"
     runs-on: ubuntu-latest
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "issues": "https://github.com/martin-helmich/typo3-typoscript-parser/issues"
     },
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.1",
         "symfony/config": "^5.4 || ^6.4",
         "symfony/dependency-injection": "^5.4 || ^6.4",
         "symfony/yaml": "^5.4 || ^6.4"

--- a/src/Parser/AST/Builder.php
+++ b/src/Parser/AST/Builder.php
@@ -2,8 +2,6 @@
 
 namespace Helmich\TypoScriptParser\Parser\AST;
 
-use PhpParser\Node\Stmt\Nop;
-
 /**
  * Helper class for quickly building AST nodes
  *

--- a/src/Parser/AST/Builder.php
+++ b/src/Parser/AST/Builder.php
@@ -12,8 +12,7 @@ use PhpParser\Node\Stmt\Nop;
  */
 class Builder
 {
-    /** @var Operator\Builder */
-    private $operatorBuilder;
+    private Operator\Builder $operatorBuilder;
 
     /**
      * Builder constructor.
@@ -24,11 +23,8 @@ class Builder
     }
 
     /**
-     * @param string      $condition
-     * @param Statement[] $if
-     * @param Statement[] $else
-     * @param int         $line
-     * @return ConditionalStatement
+     * @psalm-param Statement[] $if
+     * @psalm-param Statement[] $else
      */
     public function condition(string $condition, array $if, array $else, int $line): ConditionalStatement
     {
@@ -50,63 +46,34 @@ class Builder
         return new NopStatement($line);
     }
 
-    /**
-     * @param string      $directory
-     * @param string|null $extensions
-     * @param string|null $condition
-     * @param int         $line
-     * @return DirectoryIncludeStatement
-     */
     public function includeDirectory(string $directory, ?string $extensions, ?string $condition, int $line): DirectoryIncludeStatement
     {
         return new DirectoryIncludeStatement($directory, $extensions, $condition, $line);
     }
 
-    /**
-     * @param string      $file
-     * @param boolean     $newSyntax
-     * @param string|null $condition
-     * @param int         $line
-     * @return FileIncludeStatement
-     */
     public function includeFile(string $file, bool $newSyntax, ?string $condition, int $line): FileIncludeStatement
     {
         return new FileIncludeStatement($file, $newSyntax, $condition, $line);
     }
 
     /**
-     * @param ObjectPath  $path
-     * @param Statement[] $statements
-     * @param int         $line
-     * @return NestedAssignment
+     * @psalm-param Statement[] $statements
      */
     public function nested(ObjectPath $path, array $statements, int $line): NestedAssignment
     {
         return new NestedAssignment($path, $statements, $line);
     }
 
-    /**
-     * @param string $value
-     * @return Scalar
-     */
     public function scalar(string $value): Scalar
     {
         return new Scalar($value);
     }
 
-    /**
-     * @param string $absolute
-     * @param string $relative
-     * @return ObjectPath
-     */
     public function path(string $absolute, string $relative): ObjectPath
     {
         return new ObjectPath($absolute, $relative);
     }
 
-    /**
-     * @return Operator\Builder
-     */
     public function op(): Operator\Builder
     {
         return $this->operatorBuilder;

--- a/src/Parser/AST/Comment.php
+++ b/src/Parser/AST/Comment.php
@@ -6,10 +6,7 @@ namespace Helmich\TypoScriptParser\Parser\AST;
 
 final class Comment extends Statement
 {
-    /**
-     * @var string
-     */
-    public $comment;
+    public string $comment;
 
     public function __construct(string $comment, int $sourceLine)
     {

--- a/src/Parser/AST/ConditionalStatement.php
+++ b/src/Parser/AST/ConditionalStatement.php
@@ -13,24 +13,22 @@ class ConditionalStatement extends Statement
 
     /**
      * The condition to evaluate.
-     *
-     * @var string
      */
-    public $condition;
+    public string $condition;
 
     /**
      * Statements within the if-branch.
      *
      * @var Statement[]
      */
-    public $ifStatements = [];
+    public array $ifStatements = [];
 
     /**
      * Statements within the else-branch.
      *
      * @var Statement[]
      */
-    public $elseStatements = [];
+    public array $elseStatements = [];
 
     /**
      * Constructs a conditional statement.

--- a/src/Parser/AST/DirectoryIncludeStatement.php
+++ b/src/Parser/AST/DirectoryIncludeStatement.php
@@ -18,25 +18,20 @@ class DirectoryIncludeStatement extends IncludeStatement
 
     /**
      * Conditional statement that is attached to this include
-     *
-     * @var string|null
      */
-    public $condition;
+    public ?string $condition;
 
     /**
      * Same as extensions
      *
-     * @var string|null
      * @deprecated Use `extensions` instead
      */
-    public $extension = null;
+    public ?string $extension = null;
 
     /**
      * An optional file extension filter. May be NULL.
-     *
-     * @var string|null
      */
-    public $extensions = null;
+    public ?string $extensions = null;
 
     /**
      * Constructs a new directory include statement.

--- a/src/Parser/AST/FileIncludeStatement.php
+++ b/src/Parser/AST/FileIncludeStatement.php
@@ -17,9 +17,8 @@ class FileIncludeStatement extends IncludeStatement
 
     /**
      * Conditional statement that is attached to this include
-     * @var string|null
      */
-    public $condition;
+    public ?string $condition;
 
     /**
      * Determines if this statement uses the new @import syntax

--- a/src/Parser/AST/MultilineComment.php
+++ b/src/Parser/AST/MultilineComment.php
@@ -6,10 +6,7 @@ namespace Helmich\TypoScriptParser\Parser\AST;
 
 final class MultilineComment extends Statement
 {
-    /**
-     * @var string
-     */
-    public $comment;
+    public string $comment;
 
     public function __construct(string $comment, int $sourceLine)
     {

--- a/src/Parser/AST/NestedAssignment.php
+++ b/src/Parser/AST/NestedAssignment.php
@@ -25,17 +25,15 @@ class NestedAssignment extends Statement
 
     /**
      * The object to operate on.
-     *
-     * @var ObjectPath
      */
-    public $object;
+    public ObjectPath $object;
 
     /**
      * The nested statements.
      *
      * @var Statement[]
      */
-    public $statements;
+    public array $statements;
 
     /**
      * @param ObjectPath  $object     The object to operate on.

--- a/src/Parser/AST/ObjectPath.php
+++ b/src/Parser/AST/ObjectPath.php
@@ -14,17 +14,13 @@ class ObjectPath
 {
     /**
      * The relative object path, as specified in the source code.
-     *
-     * @var string
      */
-    public $relativeName;
+    public string $relativeName;
 
     /**
      * The absolute object path, as evaluated from parent nested statements.
-     *
-     * @var string
      */
-    public $absoluteName;
+    public string $absoluteName;
 
     /**
      * Constructs a new object path.
@@ -38,9 +34,6 @@ class ObjectPath
         $this->relativeName = $relativeName;
     }
 
-    /**
-     * @return int
-     */
     public function depth(): int
     {
         return count(explode('.', $this->absoluteName));
@@ -62,10 +55,6 @@ class ObjectPath
         return new self(implode('.', $components), $components[count($components) - 1]);
     }
 
-    /**
-     * @param string $name
-     * @return self
-     */
     public function append(string $name): self
     {
         if ($name[0] === '.' && $name !== '.') {

--- a/src/Parser/AST/Operator/Assignment.php
+++ b/src/Parser/AST/Operator/Assignment.php
@@ -20,10 +20,8 @@ class Assignment extends BinaryOperator
     /**
      * The value to be assigned. Should be a scalar value, which MAY contain
      * a constant evaluation expression (like "${foo.bar}").
-     *
-     * @var Scalar
      */
-    public $value;
+    public Scalar $value;
 
     /**
      * Constructs an assignment.

--- a/src/Parser/AST/Operator/BinaryObjectOperator.php
+++ b/src/Parser/AST/Operator/BinaryObjectOperator.php
@@ -14,8 +14,6 @@ abstract class BinaryObjectOperator extends BinaryOperator
 {
     /**
      * The target object to reference to or copy from.
-     *
-     * @var ObjectPath
      */
-    public $target;
+    public ObjectPath $target;
 }

--- a/src/Parser/AST/Operator/BinaryOperator.php
+++ b/src/Parser/AST/Operator/BinaryOperator.php
@@ -9,14 +9,12 @@ use Helmich\TypoScriptParser\Parser\AST\Statement;
  * Abstract base class for statements with binary operators.
  *
  * @package    Helmich\TypoScriptParser
- * @subpcakage Parser\AST\Operator
+ * @subpackage Parser\AST\Operator
  */
 abstract class BinaryOperator extends Statement
 {
     /**
      * The object on the left-hand side of the statement.
-     *
-     * @var ObjectPath
      */
-    public $object;
+    public ObjectPath $object;
 }

--- a/src/Parser/AST/Operator/Builder.php
+++ b/src/Parser/AST/Operator/Builder.php
@@ -2,19 +2,22 @@
 
 namespace Helmich\TypoScriptParser\Parser\AST\Operator;
 
+use Helmich\TypoScriptParser\Parser\AST\ObjectPath;
+use Helmich\TypoScriptParser\Parser\AST\Scalar;
+
 /**
  * Helper class for quickly building operator AST nodes
  *
  * @package    Helmich\TypoScriptParser
  * @subpackage Parser\AST\Operator
  *
- * @method ObjectCreation objectCreation($path, $value, $line)
- * @method Assignment assignment($path, $value, $line)
- * @method Copy copy($path, $value, $line)
- * @method Reference reference($path, $value, $line)
- * @method Delete delete($path, $line)
- * @method ModificationCall modificationCall($method, $arguments)
- * @method Modification modification($path, $call, $line)
+ * @method ObjectCreation objectCreation(ObjectPath $path, Scalar $value, int $line)
+ * @method Assignment assignment(ObjectPath $path, Scalar $value, int $line)
+ * @method Copy copy(ObjectPath $path, ObjectPath $value, int $line)
+ * @method Reference reference(ObjectPath $path, ObjectPath $value, int $line)
+ * @method Delete delete(ObjectPath $path, int $line)
+ * @method ModificationCall modificationCall(string $method, string $arguments)
+ * @method Modification modification(ObjectPath $path, ModificationCall $call, int $line)
  */
 class Builder
 {

--- a/src/Parser/AST/Operator/Modification.php
+++ b/src/Parser/AST/Operator/Modification.php
@@ -17,12 +17,7 @@ use Helmich\TypoScriptParser\Parser\AST\ObjectPath;
  */
 class Modification extends BinaryOperator
 {
-    /**
-     * The modification call.
-     *
-     * @var ModificationCall
-     */
-    public $call;
+    public ModificationCall $call;
 
     /**
      * Constructs a modification statement.

--- a/src/Parser/AST/Operator/ModificationCall.php
+++ b/src/Parser/AST/Operator/ModificationCall.php
@@ -12,17 +12,13 @@ class ModificationCall
 {
     /**
      * The method name.
-     *
-     * @var string
      */
-    public $method;
+    public string $method;
 
     /**
      * The argument list.
-     *
-     * @var string
      */
-    public $arguments;
+    public string $arguments;
 
     /**
      * Modification call constructor.

--- a/src/Parser/AST/Operator/UnaryOperator.php
+++ b/src/Parser/AST/Operator/UnaryOperator.php
@@ -15,10 +15,8 @@ abstract class UnaryOperator extends Statement
 {
     /**
      * The object the operator should be applied on.
-     *
-     * @var ObjectPath
      */
-    public $object;
+    public ObjectPath $object;
 
     /**
      * Constructs a unary operator statement.

--- a/src/Parser/AST/RootObjectPath.php
+++ b/src/Parser/AST/RootObjectPath.php
@@ -10,35 +10,22 @@ namespace Helmich\TypoScriptParser\Parser\AST;
  */
 class RootObjectPath extends ObjectPath
 {
-    /**
-     * RootObjectPath constructor.
-     */
     public function __construct()
     {
         parent::__construct('', '');
     }
 
-    /**
-     * @return ObjectPath
-     */
     public function parent(): ObjectPath
     {
         return $this;
     }
 
-    /**
-     * @return int
-     */
     public function depth(): int
     {
         return 0;
     }
 
-    /**
-     * @param string $name
-     * @return ObjectPath
-     */
-    public function append($name): ObjectPath
+    public function append(string $name): ObjectPath
     {
         return new ObjectPath(ltrim($name, '.'), $name);
     }

--- a/src/Parser/AST/Scalar.php
+++ b/src/Parser/AST/Scalar.php
@@ -10,18 +10,8 @@ namespace Helmich\TypoScriptParser\Parser\AST;
  */
 class Scalar
 {
-    /**
-     * The value.
-     *
-     * @var string
-     */
-    public $value;
+    public string $value;
 
-    /**
-     * Constructs a scalar value.
-     *
-     * @param string $value The value.
-     */
     public function __construct(string $value)
     {
         $this->value = $value;

--- a/src/Parser/AST/Statement.php
+++ b/src/Parser/AST/Statement.php
@@ -12,10 +12,8 @@ abstract class Statement
 {
     /**
      * The original source line. Useful for tracing and debugging.
-     *
-     * @var int
      */
-    public $sourceLine;
+    public int $sourceLine;
 
     /**
      * Base statement constructor.

--- a/src/Parser/ParseError.php
+++ b/src/Parser/ParseError.php
@@ -7,8 +7,7 @@ use Exception;
 class ParseError extends \Exception
 {
 
-    /** @var int|null */
-    private $sourceLine;
+    private ?int $sourceLine;
 
     public function __construct(string $message = "", int $code = 0, ?int $line = null, Exception $previous = null)
     {

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -431,7 +431,7 @@ class Parser implements ParserInterface
         }
 
         $state->statements()->append($this->builder->op()->delete($state->context(), $state->token(1)->getLine()));
-        $state->next(1);
+        $state->next();
     }
 
     private function parseMultilineAssigment(ParserState $state): void

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -16,18 +16,10 @@ use Helmich\TypoScriptParser\Tokenizer\TokenizerInterface;
  */
 class Parser implements ParserInterface
 {
-    /** @var TokenizerInterface */
-    private $tokenizer;
+    private TokenizerInterface $tokenizer;
 
-    /** @var Builder */
-    private $builder;
+    private Builder $builder;
 
-    /**
-     * Parser constructor.
-     *
-     * @param TokenizerInterface $tokenizer
-     * @param Builder|null       $astBuilder
-     */
     public function __construct(TokenizerInterface $tokenizer, Builder $astBuilder = null)
     {
         $this->tokenizer = $tokenizer;
@@ -41,6 +33,7 @@ class Parser implements ParserInterface
      *
      * @param string $stream The stream resource.
      * @return Statement[] The syntax tree.
+     * @throws ParseError
      */
     public function parseStream(string $stream): array
     {
@@ -57,6 +50,7 @@ class Parser implements ParserInterface
      *
      * @param string $string The string to parse.
      * @return Statement[] The syntax tree.
+     * @throws ParseError
      */
     public function parseString(string $string): array
     {
@@ -69,6 +63,7 @@ class Parser implements ParserInterface
      *
      * @param TokenInterface[] $tokens The token stream to parse.
      * @return Statement[] The syntax tree.
+     * @throws ParseError
      */
     public function parseTokens(array $tokens): array
     {
@@ -91,8 +86,6 @@ class Parser implements ParserInterface
     }
 
     /**
-     * @param ParserState $state
-     * @return void
      * @throws ParseError
      */
     private function parseToken(ParserState $state): void
@@ -153,9 +146,6 @@ class Parser implements ParserInterface
     }
 
     /**
-     * @param ParserState $state
-     * @param int|null    $startLine
-     * @return void
      * @throws ParseError
      */
     private function parseNestedStatements(ParserState $state, ?int $startLine = null): void
@@ -197,7 +187,6 @@ class Parser implements ParserInterface
     }
 
     /**
-     * @param ParserState $state
      * @throws ParseError
      */
     private function parseCondition(ParserState $state): void
@@ -270,9 +259,6 @@ class Parser implements ParserInterface
         }
     }
 
-    /**
-     * @param ParserState $state
-     */
     private function parseInclude(ParserState $state): void
     {
         $token = $state->token();
@@ -304,12 +290,6 @@ class Parser implements ParserInterface
         $state->statements()->append($node);
     }
 
-    /**
-     * @param string         $optional
-     * @param TokenInterface $token
-     * @return array
-     * @throws ParseError
-     */
     private function parseIncludeOptionals(string $optional, TokenInterface $token): array
     {
         if (!(preg_match_all('/((?<key>[a-z]+)="(?<value>[^"]*)\s*)+"/', $optional, $matches) > 0)) {
@@ -342,10 +322,6 @@ class Parser implements ParserInterface
         return [$extensions, $condition];
     }
 
-    /**
-     * @param ParserState $state
-     * @throws ParseError
-     */
     private function parseValueOperation(ParserState $state): void
     {
         switch ($state->token(1)->getType()) {
@@ -368,9 +344,6 @@ class Parser implements ParserInterface
         }
     }
 
-    /**
-     * @param ParserState $state
-     */
     private function parseAssignment(ParserState $state): void
     {
         switch ($state->token(2)->getType()) {
@@ -402,10 +375,6 @@ class Parser implements ParserInterface
         }
     }
 
-    /**
-     * @param ParserState $state
-     * @throws ParseError
-     */
     private function parseCopyOrReference(ParserState $state): void
     {
         $targetToken = $state->token(2);
@@ -424,7 +393,6 @@ class Parser implements ParserInterface
     }
 
     /**
-     * @param ParserState $state
      * @throws ParseError
      */
     private function parseModification(ParserState $state): void
@@ -448,7 +416,6 @@ class Parser implements ParserInterface
     }
 
     /**
-     * @param ParserState $state
      * @throws ParseError
      */
     private function parseDeletion(ParserState $state): void
@@ -467,9 +434,6 @@ class Parser implements ParserInterface
         $state->next(1);
     }
 
-    /**
-     * @param ParserState $state
-     */
     private function parseMultilineAssigment(ParserState $state): void
     {
         $state->statements()->append($this->builder->op()->assignment(
@@ -481,7 +445,6 @@ class Parser implements ParserInterface
     }
 
     /**
-     * @param TokenInterface $token
      * @throws ParseError
      */
     private function validateModifyOperatorRightValue(TokenInterface $token): void
@@ -496,7 +459,6 @@ class Parser implements ParserInterface
     }
 
     /**
-     * @param TokenInterface $token
      * @throws ParseError
      */
     private function validateCopyOperatorRightValue(TokenInterface $token): void

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -400,10 +400,18 @@ class Parser implements ParserInterface
         $token = $state->token(2);
         $this->validateModifyOperatorRightValue($token);
 
-        $call = $this->builder->op()->modificationCall(
-            $token->getSubMatch('name'),
-            $token->getSubMatch('arguments')
-        );
+        $name = $token->getSubMatch('name');
+        $arguments = $token->getSubMatch('arguments');
+
+        if ($name === null || $arguments === null) {
+            throw new ParseError(
+                'Invalid modification call; name or arguments are null',
+                1403011201,
+                $token->getLine()
+            );
+        }
+
+        $call = $this->builder->op()->modificationCall($name, $arguments);
 
         $modification = $this->builder->op()->modification(
             $state->context(),

--- a/src/Parser/ParserState.php
+++ b/src/Parser/ParserState.php
@@ -9,14 +9,11 @@ use Helmich\TypoScriptParser\Tokenizer\TokenInterface;
 
 class ParserState
 {
-    /** @var ObjectPath */
-    private $context;
+    private ObjectPath $context;
 
-    /** @var ArrayObject */
-    private $statements;
+    private ArrayObject $statements;
 
-    /** @var TokenStream */
-    private $tokens;
+    private TokenStream $tokens;
 
     public function __construct(TokenStream $tokens, ArrayObject $statements = null)
     {
@@ -43,43 +40,26 @@ class ParserState
         return $clone;
     }
 
-    /**
-     * @param int $lookAhead
-     * @return TokenInterface
-     */
     public function token(int $lookAhead = 0): TokenInterface
     {
         return $this->tokens->current($lookAhead);
     }
 
-    /**
-     * @param int $increment
-     * @return void
-     */
     public function next(int $increment = 1): void
     {
         $this->tokens->next($increment);
     }
 
-    /**
-     * @return bool
-     */
     public function hasNext(): bool
     {
         return $this->tokens->valid();
     }
 
-    /**
-     * @return ObjectPath
-     */
     public function context(): ObjectPath
     {
         return $this->context;
     }
 
-    /**
-     * @return ArrayObject
-     */
     public function statements(): ArrayObject
     {
         return $this->statements;

--- a/src/Parser/Printer/ASTPrinterInterface.php
+++ b/src/Parser/Printer/ASTPrinterInterface.php
@@ -2,19 +2,15 @@
 
 namespace Helmich\TypoScriptParser\Parser\Printer;
 
+use Helmich\TypoScriptParser\Parser\AST\Statement;
 use Symfony\Component\Console\Output\OutputInterface;
 
 interface ASTPrinterInterface
 {
     /**
-     * @param \Helmich\TypoScriptParser\Parser\AST\Statement[]  $statements
-     * @param \Symfony\Component\Console\Output\OutputInterface $output
-     * @return void
+     * @psalm-param Statement[] $statements
      */
     public function printStatements(array $statements, OutputInterface $output): void;
 
-    /**
-     * @param PrettyPrinterConfiguration $prettyPrinterConfiguration
-     */
     public function setPrettyPrinterConfiguration(PrettyPrinterConfiguration $prettyPrinterConfiguration): void;
 }

--- a/src/Parser/Printer/PrettyPrinter.php
+++ b/src/Parser/Printer/PrettyPrinter.php
@@ -46,7 +46,7 @@ class PrettyPrinter implements ASTPrinterInterface
      */
     public function printStatements(array $statements, OutputInterface $output): void
     {
-        $this->printStatementList($statements, $output, 0);
+        $this->printStatementList($statements, $output);
     }
 
     private function trimTrailingNoops(array $statements): array

--- a/src/Parser/Printer/PrettyPrinter.php
+++ b/src/Parser/Printer/PrettyPrinter.php
@@ -43,9 +43,7 @@ class PrettyPrinter implements ASTPrinterInterface
     }
 
     /**
-     * @param Statement[]     $statements
-     * @param OutputInterface $output
-     * @return void
+     * @psalm-param Statement[] $statements
      */
     public function printStatements(array $statements, OutputInterface $output): void
     {
@@ -64,10 +62,7 @@ class PrettyPrinter implements ASTPrinterInterface
     }
 
     /**
-     * @param Statement[]     $statements
-     * @param OutputInterface $output
-     * @param int             $nesting
-     * @return void
+     * @psalm-param Statement[] $statements
      */
     private function printStatementList(array $statements, OutputInterface $output, int $nesting = 0): void
     {
@@ -176,24 +171,13 @@ class PrettyPrinter implements ASTPrinterInterface
         $output->writeln($includeStmt);
     }
 
-    /**
-     * @param OutputInterface  $output
-     * @param int              $nesting
-     * @param NestedAssignment $statement
-     */
-    private function printNestedAssignment(OutputInterface $output, $nesting, NestedAssignment $statement): void
+    private function printNestedAssignment(OutputInterface $output, int $nesting, NestedAssignment $statement): void
     {
         $output->writeln($this->getIndent($nesting) . $statement->object->relativeName . ' {');
         $this->printStatementList($statement->statements, $output, $nesting + 1);
         $output->writeln($this->getIndent($nesting) . '}');
     }
 
-    /**
-     * @param OutputInterface      $output
-     * @param int                  $nesting
-     * @param ConditionalStatement $statement
-     * @param bool                 $hasNext
-     */
     private function printConditionalStatement(OutputInterface $output, int $nesting, ConditionalStatement $statement, bool $hasNext = false): void
     {
         $conditionNesting = $nesting;
@@ -214,11 +198,6 @@ class PrettyPrinter implements ASTPrinterInterface
         }
     }
 
-    /**
-     * @param OutputInterface $output
-     * @param Assignment      $statement
-     * @param string          $indent
-     */
     private function printAssignment(OutputInterface $output, Assignment $statement, string $indent): void
     {
         if (str_contains($statement->value->value, "\n")) {

--- a/src/Parser/Printer/PrettyPrinter.php
+++ b/src/Parser/Printer/PrettyPrinter.php
@@ -19,7 +19,6 @@ use Helmich\TypoScriptParser\Parser\AST\Operator\Delete;
 use Helmich\TypoScriptParser\Parser\AST\Operator\Modification;
 use Helmich\TypoScriptParser\Parser\AST\Operator\Reference;
 use Helmich\TypoScriptParser\Parser\AST\Statement;
-use Helmich\TypoScriptParser\Tokenizer\Preprocessing\NoOpPreprocessor;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Parser/Printer/PrettyPrinterConfiguration.php
+++ b/src/Parser/Printer/PrettyPrinterConfiguration.php
@@ -13,14 +13,8 @@ namespace Helmich\TypoScriptParser\Parser\Printer;
  */
 final class PrettyPrinterConfiguration
 {
-    /**
-     * @var string
-     */
     public const INDENTATION_STYLE_SPACES = 'spaces';
 
-    /**
-     * @var string
-     */
     public const INDENTATION_STYLE_TABS = 'tabs';
 
     private bool $addClosingGlobal = false;

--- a/src/Parser/TokenStream.php
+++ b/src/Parser/TokenStream.php
@@ -34,19 +34,11 @@ class TokenStream implements Iterator, ArrayAccess
         $this->tokens = $tokens;
     }
 
-    /**
-     * @param int $lookAhead
-     * @return TokenInterface
-     */
     public function current(int $lookAhead = 0): TokenInterface
     {
         return $this[$this->index + $lookAhead];
     }
 
-    /**
-     * @param int $increment
-     * @return void
-     */
     public function next(int $increment = 1): void
     {
         if ($this->index < count($this->tokens)) {
@@ -54,25 +46,16 @@ class TokenStream implements Iterator, ArrayAccess
         }
     }
 
-    /**
-     * @return bool
-     */
     public function valid(): bool
     {
         return ($this->index) < count($this->tokens);
     }
 
-    /**
-     * @return void
-     */
     public function rewind(): void
     {
         $this->index = 0;
     }
 
-    /**
-     * @return int
-     */
     public function key(): int
     {
         return $this->index;
@@ -101,8 +84,7 @@ class TokenStream implements Iterator, ArrayAccess
      * @param TokenInterface|null $value
      * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         throw new BadMethodCallException('changing a token stream is not permitted');
     }
@@ -111,8 +93,7 @@ class TokenStream implements Iterator, ArrayAccess
      * @param int $offset
      * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         throw new BadMethodCallException('changing a token stream is not permitted');
     }

--- a/src/Parser/Traverser/AggregatingVisitor.php
+++ b/src/Parser/Traverser/AggregatingVisitor.php
@@ -13,20 +13,15 @@ use Helmich\TypoScriptParser\Parser\AST\Statement;
 class AggregatingVisitor implements Visitor
 {
     /** @var Visitor[] */
-    private $visitors = [];
+    private array $visitors = [];
 
-    /**
-     * @param Visitor $visitor
-     * @return void
-     */
     public function addVisitor(Visitor $visitor): void
     {
         $this->visitors[spl_object_hash($visitor)] = $visitor;
     }
 
     /**
-     * @param Statement[] $statements
-     * @return void
+     * @psalm-param Statement[] $statements
      */
     public function enterTree(array $statements): void
     {
@@ -35,10 +30,6 @@ class AggregatingVisitor implements Visitor
         }
     }
 
-    /**
-     * @param Statement $statement
-     * @return void
-     */
     public function enterNode(Statement $statement): void
     {
         foreach ($this->visitors as $visitor) {
@@ -46,10 +37,6 @@ class AggregatingVisitor implements Visitor
         }
     }
 
-    /**
-     * @param Statement $statement
-     * @return void
-     */
     public function exitNode(Statement $statement): void
     {
         foreach ($this->visitors as $visitor) {
@@ -58,8 +45,7 @@ class AggregatingVisitor implements Visitor
     }
 
     /**
-     * @param Statement[] $statements
-     * @return void
+     * @psalm-param Statement[] $statements
      */
     public function exitTree(array $statements): void
     {

--- a/src/Parser/Traverser/Traverser.php
+++ b/src/Parser/Traverser/Traverser.php
@@ -15,13 +15,12 @@ use Helmich\TypoScriptParser\Parser\AST\Statement;
 class Traverser
 {
     /** @var Statement[] */
-    private $statements;
+    private array $statements;
 
-    /** @var AggregatingVisitor */
-    private $visitors;
+    private AggregatingVisitor $visitors;
 
     /**
-     * @param Statement[] $statements
+     * @psalm-param Statement[] $statements
      */
     public function __construct(array $statements)
     {
@@ -29,17 +28,11 @@ class Traverser
         $this->visitors   = new AggregatingVisitor();
     }
 
-    /**
-     * @param Visitor $visitor
-     */
     public function addVisitor(Visitor $visitor): void
     {
         $this->visitors->addVisitor($visitor);
     }
 
-    /**
-     * @return void
-     */
     public function walk(): void
     {
         $this->visitors->enterTree($this->statements);

--- a/src/Tokenizer/LineGrouper.php
+++ b/src/Tokenizer/LineGrouper.php
@@ -11,7 +11,7 @@ namespace Helmich\TypoScriptParser\Tokenizer;
 class LineGrouper
 {
     /** @var TokenInterface[][] */
-    private $tokensByLine = [];
+    private array $tokensByLine = [];
 
     /**
      * @param TokenInterface[] $tokens

--- a/src/Tokenizer/MultilineTokenBuilder.php
+++ b/src/Tokenizer/MultilineTokenBuilder.php
@@ -12,17 +12,13 @@ namespace Helmich\TypoScriptParser\Tokenizer;
  */
 class MultilineTokenBuilder
 {
-    /** @var string|null */
-    private $type = null;
+    private ?string $type = null;
 
-    /** @var string|null */
-    private $value = null;
+    private ?string $value = null;
 
-    /** @var int|null */
-    private $startLine = null;
+    private ?int $startLine = null;
 
-    /** @var int|null */
-    private $startColumn = null;
+    private ?int $startColumn = null;
 
     /**
      * @param string $type   Token type, one of `TokenInterface::TYPE_*`

--- a/src/Tokenizer/Preprocessing/ProcessorChain.php
+++ b/src/Tokenizer/Preprocessing/ProcessorChain.php
@@ -12,12 +12,8 @@ namespace Helmich\TypoScriptParser\Tokenizer\Preprocessing;
 class ProcessorChain implements Preprocessor
 {
     /** @var Preprocessor[] */
-    protected $processors = [];
+    protected array $processors = [];
 
-    /**
-     * @param Preprocessor $next
-     * @return self
-     */
     public function with(Preprocessor $next): self
     {
         $new             = new self();

--- a/src/Tokenizer/Preprocessing/UnifyLineEndingsPreprocessor.php
+++ b/src/Tokenizer/Preprocessing/UnifyLineEndingsPreprocessor.php
@@ -9,8 +9,7 @@ namespace Helmich\TypoScriptParser\Tokenizer\Preprocessing;
  */
 class UnifyLineEndingsPreprocessor implements Preprocessor
 {
-    /** @var string */
-    private $eolCharacter;
+    private string $eolCharacter;
 
     public function __construct(string $eolCharacter = "\n")
     {

--- a/src/Tokenizer/Printer/StructuredTokenPrinter.php
+++ b/src/Tokenizer/Printer/StructuredTokenPrinter.php
@@ -7,8 +7,7 @@ use Symfony\Component\Yaml\Yaml;
 
 class StructuredTokenPrinter implements TokenPrinterInterface
 {
-    /** @var Yaml */
-    private $yaml;
+    private Yaml $yaml;
 
     public function __construct(Yaml $yaml = null)
     {

--- a/src/Tokenizer/Scanner.php
+++ b/src/Tokenizer/Scanner.php
@@ -15,7 +15,7 @@ use Iterator;
 class Scanner implements Iterator
 {
     /** @var string[] */
-    private array $lines = [];
+    private array $lines;
 
     private int $index = 0;
 

--- a/src/Tokenizer/ScannerLine.php
+++ b/src/Tokenizer/ScannerLine.php
@@ -20,7 +20,7 @@ class ScannerLine
      * @psalm-param non-empty-string $pattern
      * @return string[]|false
      */
-    public function scan(string $pattern)
+    public function scan(string $pattern): array|false
     {
         if (preg_match($pattern, $this->line, $matches)) {
             $matchingPart = substr($this->line, strlen($matches[0]));
@@ -36,7 +36,7 @@ class ScannerLine
      * @psalm-param non-empty-string $pattern
      * @return string[]|false
      */
-    public function peek(string $pattern)
+    public function peek(string $pattern): array|false
     {
         if (preg_match($pattern, $this->line, $matches)) {
             return $matches;

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -4,28 +4,16 @@ namespace Helmich\TypoScriptParser\Tokenizer;
 
 class Token implements TokenInterface
 {
-    /** @var string */
-    private $type;
+    private string $type;
 
-    /** @var string */
-    private $value;
+    private string $value;
 
-    /** @var int */
-    private $line;
+    private int $line;
 
-    /** @var int */
-    private $column;
+    private int $column;
 
-    /** @var array */
-    private $patternMatches;
+    private array $patternMatches;
 
-    /**
-     * @param string $type
-     * @param string $value
-     * @param int    $line
-     * @param int    $column
-     * @param array  $patternMatches
-     */
     public function __construct(string $type, string $value, int $line, int $column = 1, array $patternMatches = [])
     {
         $this->type           = $type;
@@ -35,42 +23,26 @@ class Token implements TokenInterface
         $this->patternMatches = $patternMatches;
     }
 
-    /**
-     * @return string
-     */
     public function getType(): string
     {
         return $this->type;
     }
 
-    /**
-     * @return string
-     */
     public function getValue(): string
     {
         return $this->value;
     }
 
-    /**
-     * @param string $name
-     * @return string|null
-     */
     public function getSubMatch(string $name): ?string
     {
         return isset($this->patternMatches[$name]) ? $this->patternMatches[$name] : null;
     }
 
-    /**
-     * @return int
-     */
     public function getLine(): int
     {
         return $this->line;
     }
 
-    /**
-     * @return int
-     */
     public function getColumn(): int
     {
         return $this->column;

--- a/src/Tokenizer/TokenStreamBuilder.php
+++ b/src/Tokenizer/TokenStreamBuilder.php
@@ -12,14 +12,11 @@ use ArrayObject;
  */
 class TokenStreamBuilder
 {
-    /** @var ArrayObject */
-    private $tokens;
+    private ArrayObject $tokens;
 
-    /** @var int|null */
-    private $currentLine = null;
+    private ?int $currentLine = null;
 
-    /** @var int */
-    private $currentColumn = 1;
+    private int $currentColumn = 1;
 
     /**
      * TokenStreamBuilder constructor.
@@ -69,9 +66,6 @@ class TokenStreamBuilder
         return $this->tokens->count();
     }
 
-    /**
-     * @return int
-     */
     public function currentColumn(): int
     {
         return $this->currentColumn;

--- a/src/Tokenizer/TokenizerException.php
+++ b/src/Tokenizer/TokenizerException.php
@@ -12,8 +12,7 @@ namespace Helmich\TypoScriptParser\Tokenizer;
  */
 class TokenizerException extends \Exception
 {
-    /** @var int|null */
-    private $sourceLine;
+    private ?int $sourceLine;
 
     /**
      * Constructs a new tokenizer exception.
@@ -23,7 +22,7 @@ class TokenizerException extends \Exception
      * @param \Exception|null $previous   A nested previous exception.
      * @param int|null        $sourceLine The original source line.
      */
-    public function __construct(string $message = "", int $code = 0, \Exception $previous = null, int $sourceLine = null)
+    public function __construct(string $message = "", int $code = 0, \Exception $previous = null, ?int $sourceLine = null)
     {
         parent::__construct($message, $code, $previous);
 


### PR DESCRIPTION
This PR raises the required PHP version to >=8.1 (which is the oldest not-yet-EOL).

It also removes a few workarounds needed for older PHP versions (union types, for example) and includes a lot of general cleanup 
(type annotations that have become superflous with actual parameter+property types).
