### PR TITLE
Allow slashes to occur in object paths

### DIFF
--- a/src/Tokenizer/Tokenizer.php
+++ b/src/Tokenizer/Tokenizer.php
@@ -9,7 +9,7 @@ use Helmich\TypoScriptParser\Tokenizer\Preprocessing\StandardPreprocessor;
 
 class Tokenizer implements TokenizerInterface
 {
-    const OBJECT_ACCESSOR = '((?:\.)|(?:[a-zA-Z0-9_\-\\\\:\$\{\}]+(?:\.[a-zA-Z0-9_\-\\\\:\$\{\}]*)*))';
+    const OBJECT_ACCESSOR = '((?:\.)|(?:[a-zA-Z0-9_\-\\\\:\$\{\}/]+(?:\.[a-zA-Z0-9_\-\\\\:\$\{\}/]*)*))';
 
     const TOKEN_WHITESPACE = ',^[ \t\n]+,s';
     const TOKEN_COMMENT_ONELINE = ',^(#|/)[^\n]*,';

--- a/tests/functional/Parser/Fixtures/Assignments/issue_86.php
+++ b/tests/functional/Parser/Fixtures/Assignments/issue_86.php
@@ -1,0 +1,21 @@
+<?php
+
+use Helmich\TypoScriptParser\Parser\AST\NestedAssignment;
+use Helmich\TypoScriptParser\Parser\AST\NopStatement;
+use Helmich\TypoScriptParser\Parser\AST\ObjectPath;
+use Helmich\TypoScriptParser\Parser\AST\Operator\Assignment;
+use Helmich\TypoScriptParser\Parser\AST\Scalar;
+
+return [
+    new NestedAssignment(
+        new ObjectPath('templates.vendor/package', 'templates.vendor/package'),
+        [
+            new Assignment(
+                new ObjectPath('templates.vendor/package.10', '10'),
+                new Scalar('vendor/otherpackage/Resources/Private/Backend'),
+                2,
+            ),
+        ],
+        1,
+    ),
+];

--- a/tests/functional/Parser/Fixtures/Assignments/issue_86.typoscript
+++ b/tests/functional/Parser/Fixtures/Assignments/issue_86.typoscript
@@ -1,0 +1,3 @@
+templates.vendor/package {
+    10 = vendor/otherpackage/Resources/Private/Backend
+}


### PR DESCRIPTION
- Add failing test for object key containing a slash
- Allow slashes to occur in object paths

Fixes #86
