### PR TITLE
Fix conditions w/o trailing [global] being ignored

### DIFF
--- a/src/Parser/AST/Builder.php
+++ b/src/Parser/AST/Builder.php
@@ -24,9 +24,9 @@ class Builder
      * @param Statement[] $if
      * @param Statement[] $else
      */
-    public function condition(string $condition, array $if, array $else, int $line): ConditionalStatement
+    public function condition(string $condition, array $if, array $else, int $line, bool $unterminated = false): ConditionalStatement
     {
-        return new ConditionalStatement($condition, $if, $else, $line);
+        return new ConditionalStatement($condition, $if, $else, $line, $unterminated);
     }
 
     public function comment(string $comment, int $line): Comment

--- a/src/Parser/AST/Builder.php
+++ b/src/Parser/AST/Builder.php
@@ -21,8 +21,8 @@ class Builder
     }
 
     /**
-     * @psalm-param Statement[] $if
-     * @psalm-param Statement[] $else
+     * @param Statement[] $if
+     * @param Statement[] $else
      */
     public function condition(string $condition, array $if, array $else, int $line): ConditionalStatement
     {

--- a/src/Parser/AST/ConditionalStatement.php
+++ b/src/Parser/AST/ConditionalStatement.php
@@ -31,6 +31,15 @@ class ConditionalStatement extends Statement
     public array $elseStatements = [];
 
     /**
+     * This indicates if the conditional statement was property terminated with
+     * a [global] statement.
+     *
+     * This information is not that important for parsing or printing, but might
+     * be of interest to linters.
+     */
+    public bool $unterminated = false;
+
+    /**
      * Constructs a conditional statement.
      *
      * @param string      $condition      The condition statement
@@ -38,12 +47,13 @@ class ConditionalStatement extends Statement
      * @param Statement[] $elseStatements The statements in the else-branch (may be empty).
      * @param int         $sourceLine     The original source line.
      */
-    public function __construct(string $condition, array $ifStatements, array $elseStatements, int $sourceLine)
+    public function __construct(string $condition, array $ifStatements, array $elseStatements, int $sourceLine, bool $unterminated = false)
     {
         parent::__construct($sourceLine);
 
         $this->condition      = $condition;
         $this->ifStatements   = $ifStatements;
         $this->elseStatements = $elseStatements;
+        $this->unterminated   = $unterminated;
     }
 }

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -206,6 +206,7 @@ class Parser implements ParserInterface
         $conditionLine = $state->token()->getLine();
 
         $inElseBranch = false;
+        $conditionEnded = false;
         $subContext   = $state->withStatements($ifStatements);
 
         $state->next();
@@ -219,6 +220,7 @@ class Parser implements ParserInterface
                     $conditionLine
                 ));
                 $state->next();
+                $conditionEnded = true;
                 break;
             } elseif ($state->token()->getType() === TokenInterface::TYPE_CONDITION_ELSE) {
                 $this->triggerParseErrorIf(
@@ -240,6 +242,7 @@ class Parser implements ParserInterface
                         $conditionLine
                     )
                 );
+                $conditionEnded = true;
                 $this->parseCondition($state);
                 break;
             }
@@ -256,6 +259,16 @@ class Parser implements ParserInterface
             }
 
             $this->parseToken($subContext);
+        }
+
+        if (!$conditionEnded) {
+            $state->statements()->append($this->builder->condition(
+                $condition,
+                $ifStatements->getArrayCopy(),
+                $elseStatements->getArrayCopy(),
+                $conditionLine,
+            ));
+            $state->next();
         }
     }
 

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -267,6 +267,7 @@ class Parser implements ParserInterface
                 $ifStatements->getArrayCopy(),
                 $elseStatements->getArrayCopy(),
                 $conditionLine,
+                unterminated: true,
             ));
             $state->next();
         }

--- a/tests/functional/Parser/Fixtures/Assignments/condition_expr_wo_global.php
+++ b/tests/functional/Parser/Fixtures/Assignments/condition_expr_wo_global.php
@@ -1,17 +1,21 @@
 <?php
 return [
     new \Helmich\TypoScriptParser\Parser\AST\ConditionalStatement(
-        '[5 in tree.rootLineIds || 10 in tree.rootLineIds]', [
-        new \Helmich\TypoScriptParser\Parser\AST\Operator\Assignment(
-            new \Helmich\TypoScriptParser\Parser\AST\ObjectPath('foo', 'foo'),
-            new \Helmich\TypoScriptParser\Parser\AST\Scalar('bar'),
-            2
-        ),
-        new \Helmich\TypoScriptParser\Parser\AST\Operator\Assignment(
-            new \Helmich\TypoScriptParser\Parser\AST\ObjectPath('bar', 'bar'),
-            new \Helmich\TypoScriptParser\Parser\AST\Scalar('baz'),
-            3
-        ),
-    ], [], 1
+        condition: '[5 in tree.rootLineIds || 10 in tree.rootLineIds]',
+        ifStatements: [
+            new \Helmich\TypoScriptParser\Parser\AST\Operator\Assignment(
+                new \Helmich\TypoScriptParser\Parser\AST\ObjectPath('foo', 'foo'),
+                new \Helmich\TypoScriptParser\Parser\AST\Scalar('bar'),
+                2
+            ),
+            new \Helmich\TypoScriptParser\Parser\AST\Operator\Assignment(
+                new \Helmich\TypoScriptParser\Parser\AST\ObjectPath('bar', 'bar'),
+                new \Helmich\TypoScriptParser\Parser\AST\Scalar('baz'),
+                3
+            ),
+        ],
+        elseStatements: [],
+        sourceLine: 1,
+        unterminated: true,
     ),
 ];

--- a/tests/functional/Parser/Fixtures/Assignments/condition_expr_wo_global.php
+++ b/tests/functional/Parser/Fixtures/Assignments/condition_expr_wo_global.php
@@ -1,0 +1,17 @@
+<?php
+return [
+    new \Helmich\TypoScriptParser\Parser\AST\ConditionalStatement(
+        '[5 in tree.rootLineIds || 10 in tree.rootLineIds]', [
+        new \Helmich\TypoScriptParser\Parser\AST\Operator\Assignment(
+            new \Helmich\TypoScriptParser\Parser\AST\ObjectPath('foo', 'foo'),
+            new \Helmich\TypoScriptParser\Parser\AST\Scalar('bar'),
+            2
+        ),
+        new \Helmich\TypoScriptParser\Parser\AST\Operator\Assignment(
+            new \Helmich\TypoScriptParser\Parser\AST\ObjectPath('bar', 'bar'),
+            new \Helmich\TypoScriptParser\Parser\AST\Scalar('baz'),
+            3
+        ),
+    ], [], 1
+    ),
+];

--- a/tests/functional/Parser/Fixtures/Assignments/condition_expr_wo_global.typoscript
+++ b/tests/functional/Parser/Fixtures/Assignments/condition_expr_wo_global.typoscript
@@ -1,0 +1,3 @@
+[5 in tree.rootLineIds || 10 in tree.rootLineIds]
+foo = bar
+bar = baz

--- a/tests/functional/Parser/Fixtures/Assignments/condition_expr_wo_global.typoscript.print
+++ b/tests/functional/Parser/Fixtures/Assignments/condition_expr_wo_global.typoscript.print
@@ -1,0 +1,4 @@
+[5 in tree.rootLineIds || 10 in tree.rootLineIds]
+foo = bar
+bar = baz
+[global]


### PR DESCRIPTION
Currently, conditions without a trailing `[global]` or `[end]` are ignored entirely by the parser.

In the syntax tree, unterminated conditions get a `unterminated` property set, because this information may be of interest to linters.

- **Fix condition without terminating [global] not being parsed**
- **Add "unterminated" flag to unterminated conditions**
